### PR TITLE
CIR-103 - Refactor - Megamenu CSS Grid Concept

### DIFF
--- a/assets/scss/blocks/navigation/cus-mega-menu.scss
+++ b/assets/scss/blocks/navigation/cus-mega-menu.scss
@@ -91,12 +91,12 @@
     }
 
     .level-2-items {
-      display: flex;
+      --level2-column-count: 5;
+      display: grid;
       gap: 2rem;
-      flex-wrap: wrap;
+      grid-template-columns: repeat(var(--level2-column-count), 1fr);
 
       .level-2-item {
-        // flex: 0 2 max(calc(20% - 1.6rem), 12rem);
         display: flex;
         flex-flow: column;
         row-gap: 0.5rem;
@@ -115,8 +115,6 @@
           max-height: 18rem;
           flex: 1 1 100%;
           display: block;
-          // column-width: calc(20vw - 1rem);
-          column-width: max(calc(20vw - 1rem), 10rem);
           column-gap: 2rem;
           .nav-item {
             margin-bottom: 0.75rem;
@@ -137,14 +135,9 @@
       }
 
       .level-3-items-multi-col {
+        grid-column: span var(--level3-column-count);
         .level-3-items {
-          column-count: var(--column-count);
-          &::after {
-            content: attr(data-columns);
-            width: 50px;
-            height: 50px;
-            background-color: tomato;
-          }
+          column-count: var(--level3-column-count);
         }
       }
     }
@@ -184,6 +177,23 @@ html:dir(rtl) {
             .nav-item {
               width: auto;
             }
+          }
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 1200px) {
+  .cus-mega-menu {
+    .mega-menu-drawer {
+      .level-2-items {
+        display: flex;
+        flex-direction: column;
+        .level-3-items-multi-col {
+          grid-column: unset;
+          .level-3-items {
+            column-count: 1;
           }
         }
       }

--- a/components/navigation/megamenu/NavigationMegamenuDrawer.vue
+++ b/components/navigation/megamenu/NavigationMegamenuDrawer.vue
@@ -21,7 +21,15 @@ const props = defineProps<{
         </NuxtLink>
       </li>
 
-      <div v-if="parent.children.length > 0" class="level-2-items">
+      <div
+        v-if="parent.children.length > 0"
+        :style="
+          parent.children.length < 5
+            ? `--level2-column-count: ${parent.children.length}`
+            : ''
+        "
+        class="level-2-items"
+      >
         <NavigationMegamenuLevel2 :parent="parent" />
       </div>
     </ul>

--- a/components/navigation/megamenu/NavigationMegamenuLevel2.vue
+++ b/components/navigation/megamenu/NavigationMegamenuLevel2.vue
@@ -11,6 +11,7 @@ const props = defineProps<{
     v-for="level2_item in parent.children"
     class="level-2-item nav-item"
     :class="[{ 'level-3-items-multi-col': level2_item.children.length > 8 }]"
+    :style="`--level3-column-count: ${Math.ceil(level2_item.children.length / 8).toString()}`"
   >
     <NuxtLink
       class="nav-link"
@@ -26,11 +27,7 @@ const props = defineProps<{
       <NavigationMegamenuLevel3Dynamic :parent="level2_item" />
     </ul>
 
-    <ul
-      v-else-if="level2_item.children.length > 0"
-      class="level-3-items nav"
-      :style="`--column-count: ${Math.ceil(level2_item.children.length / 8).toString()}`"
-    >
+    <ul v-else-if="level2_item.children.length > 0" class="level-3-items nav">
       <NavigationMegamenuLevel3 :parent="level2_item" />
     </ul>
   </li>


### PR DESCRIPTION
### General description

_Change Megamenu Drawers's CSS to use Grid rather than Flexbox._

### Designs

_[Figma design](https://www.figma.com/design/Fts1hOwL9nswthrm3O53n4/High-Fidelity-Wireframes?node-id=2626-20881&t=GXXqkT7KYbOOoe04-1)._

### Testing instructions

- When running the application, the style should match the styles available on the [Figma design](https://www.figma.com/design/Fts1hOwL9nswthrm3O53n4/High-Fidelity-Wireframes?node-id=2626-20881&t=GXXqkT7KYbOOoe04-1).

## Jira

Ticket: [CIR-103](https://scbd.atlassian.net/browse/CIR-103)

## Additional Notes

When testing locally, obtain the .env configuration file from the #REF channel.